### PR TITLE
fix: Pin PSR version

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -46,7 +46,7 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.FEB_2024_SECRET }}
     - name: Use Python Semantic Release to prepare Release
-      uses: relekang/python-semantic-release@master
+      uses: python-semantic-release/python-semantic-release@v7.33.5
       with:
         github_token: ${{ secrets.FEB_2024_SECRET }}
         repository_username: __token__


### PR DESCRIPTION
Pin the version of python semantic release to v7, till we can upgrade to v8